### PR TITLE
Fix path sanitization

### DIFF
--- a/index.php
+++ b/index.php
@@ -60,7 +60,9 @@ if (!isset($_SESSION['logged_in'])) {
 // --- END LOGIN HANDLING ---
 
 // Connect to user-specific workout DB
-$username = $_SESSION['username'];
+$raw_username = $_SESSION['username'];
+// Sanitize username for filesystem usage
+$username = preg_replace('/[^a-zA-Z0-9_-]/', '', $raw_username);
 $workout_db_path = "/var/www/html/data/{$username}_workout_log.db";
 $db = new PDO("sqlite:" . $workout_db_path);
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/weight_log.php
+++ b/weight_log.php
@@ -6,7 +6,9 @@ if (!isset($_SESSION['logged_in'])) {
     exit();
 }
 
-$username = $_SESSION['username'] ?? 'default';
+$raw_username = $_SESSION['username'] ?? 'default';
+// Sanitize username for filesystem usage
+$username = preg_replace('/[^a-zA-Z0-9_-]/', '', $raw_username);
 $db = new PDO("sqlite:/var/www/html/data/{$username}_weight_log.db");
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->exec("CREATE TABLE IF NOT EXISTS weights (id INTEGER PRIMARY KEY AUTOINCREMENT, date TEXT, weight REAL)");


### PR DESCRIPTION
## Summary
- sanitize usernames before using them in DB paths

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584cb4157c8331b0fddb315c3c7783