### PR TITLE
Fix exercise name for Farmer's Carries

### DIFF
--- a/index.php
+++ b/index.php
@@ -92,7 +92,7 @@ $workout_exercises = [
     'Isolation' => [
         'Biceps' => ['Barbell Preacher Curl', 'Dumbbell Preacher curl', 'Dumbbell curls', 'Cable Curls', 'Hammer curls', 'Barbell 21 Curls'],
         'Triceps' => ['Skull Crusher', 'Bench Dips', 'Cable pushdowns', 'Cable overheads'],
-        'Shoulders' => ['Dumbbell Shrugs', 'Lateral Raises', 'Farmers Carries', 'Cable Lateral Raises'],
+        'Shoulders' => ['Dumbbell Shrugs', 'Lateral Raises', "Farmer's Carries", 'Cable Lateral Raises'],
         'Hamstrings' => ['Single Leg Glute Bridge', 'Single Leg Bench Hip Thrust', 'Weighted Bench Hip Thrust', 'Slider Hamstring Curl', 'Single Leg Romanian Deadlift', 'Machine Hamstring Curl', 'Romanian Deadlift'],
         'Core' => ['Hanging Leg Raises', 'Cable Crunches', 'Forearm Plank']
     ]


### PR DESCRIPTION
## Summary
- fix exercise grammar from Farmers Carries to Farmer's Carries

## Testing
- `php -l index.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68584e17a5088331b3c233e5bbf25848