### PR TITLE
Integrate new management utilities and workout features

### DIFF
--- a/config_editor.php
+++ b/config_editor.php
@@ -1,0 +1,102 @@
+<?php
+// Only allow CLI execution
+if (php_sapi_name() !== 'cli') {
+    http_response_code(403);
+    exit("This script can only be run from the command line.\n");
+}
+
+// Connect to config DB
+$db = new PDO("sqlite:/var/www/html/data/config.db");
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+// Create tables if not exist
+$db->exec("
+CREATE TABLE IF NOT EXISTS muscle_groups (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    category TEXT CHECK(category IN ('Compound', 'Isolation')) NOT NULL,
+    display_order INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS subgroups (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    group_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    FOREIGN KEY(group_id) REFERENCES muscle_groups(id)
+);
+CREATE TABLE IF NOT EXISTS exercises (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    subgroup_id INTEGER,
+    group_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    sets INTEGER DEFAULT 3,
+    FOREIGN KEY(group_id) REFERENCES muscle_groups(id),
+    FOREIGN KEY(subgroup_id) REFERENCES subgroups(id)
+);");
+
+// Argument parsing
+$args = $argv;
+array_shift($args); // Remove script name
+
+if (count($args) === 0) {
+    echo "Usage:\n";
+    echo "  php config_editor.php -list\n";
+    echo "  php config_editor.php -add [compound|isolation] [group] [exercise name] [sets]\n";
+    exit(0);
+}
+
+$action = $args[0];
+
+if ($action === '-list') {
+    echo "Current Exercises:\n";
+
+    $groups = $db->query("SELECT id, name, category FROM muscle_groups ORDER BY category, name")->fetchAll(PDO::FETCH_ASSOC);
+    foreach ($groups as $group) {
+        $group_id = $group['id'];
+        $group_name = $group['name'];
+        $category = $group['category'];
+        echo "[$category] $group_name:\n";
+
+        $stmt = $db->prepare("SELECT name, sets FROM exercises WHERE group_id = ? AND subgroup_id IS NULL ORDER BY name");
+        $stmt->execute([$group_id]);
+        $exercises = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        foreach ($exercises as $ex) {
+            echo "  - {$ex['name']} ({$ex['sets']} sets)\n";
+        }
+    }
+
+} elseif ($action === '-add' && count($args) === 5) {
+    list($_, $category, $group, $exercise, $sets) = $args;
+
+    $category = ucfirst(strtolower($category));
+    if (!in_array($category, ['Compound', 'Isolation'])) {
+        exit("Invalid category: $category (must be 'Compound' or 'Isolation')\n");
+    }
+
+    // Check if muscle group exists
+    $stmt = $db->prepare("SELECT id FROM muscle_groups WHERE name = ? AND category = ?");
+    $stmt->execute([$group, $category]);
+    $group_id = $stmt->fetchColumn();
+
+    if (!$group_id) {
+        // Get max display_order in this category
+        $stmt = $db->prepare("SELECT MAX(display_order) FROM muscle_groups WHERE category = ?");
+        $stmt->execute([$category]);
+        $max_order = $stmt->fetchColumn();
+        $next_order = is_numeric($max_order) ? $max_order + 1 : 0;
+
+        $stmt = $db->prepare("INSERT INTO muscle_groups (name, category, display_order) VALUES (?, ?, ?)");
+        $stmt->execute([$group, $category, $next_order]);
+        $group_id = $db->lastInsertId();
+        echo "Created new muscle group: $group under $category (order $next_order)\n";
+    }
+
+    // Add exercise
+    $stmt = $db->prepare("INSERT INTO exercises (group_id, name, sets) VALUES (?, ?, ?)");
+    $stmt->execute([$group_id, $exercise, (int)$sets]);
+
+    echo "Exercise '$exercise' added to $category -> $group with $sets sets.\n";
+
+} else {
+    echo "Invalid command or arguments.\n";
+}

--- a/create_user.php
+++ b/create_user.php
@@ -5,6 +5,16 @@ if (php_sapi_name() !== 'cli') {
     exit("This script can only be run from the command line.\n");
 }
 
+// Check for correct number of arguments
+if ($argc !== 3) {
+    echo "Usage: php create_user.php <username> <password>\n";
+    exit(1);
+}
+
+$username = $argv[1];
+$plaintext = $argv[2];
+
+// Connect to the database
 $path = '/var/www/html/data/user_credentials.db';
 $db = new PDO("sqlite:$path");
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
@@ -16,12 +26,11 @@ $db->exec("CREATE TABLE IF NOT EXISTS users (
     password TEXT NOT NULL
 )");
 
-// Insert default test user with hashed password
-$username = 'user';
-$plaintext = 'defaultpassword';
+// Hash the password
 $hashed = password_hash($plaintext, PASSWORD_DEFAULT);
 
+// Insert user
 $stmt = $db->prepare("INSERT OR IGNORE INTO users (username, password) VALUES (?, ?)");
 $stmt->execute([$username, $hashed]);
 
-echo "User created or already exists.\n";
+echo "User '{$username}' created or already exists.\n";

--- a/join.php
+++ b/join.php
@@ -1,0 +1,81 @@
+<?php
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+session_start();
+
+// Redirect if already logged in
+if (isset($_SESSION['logged_in']) && $_SESSION['logged_in']) {
+    header("Location: index.php");
+    exit();
+}
+
+// Connect to credentials database
+$path = '/var/www/html/data/user_credentials.db';
+$db = new PDO("sqlite:$path");
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+// Create users table if it doesn't exist
+$db->exec("CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE NOT NULL,
+    password TEXT NOT NULL
+)");
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username'] ?? '');
+    $password = $_POST['password'] ?? '';
+
+    if ($username === '' || $password === '') {
+        $error = "Username and password are required.";
+    } else {
+        // Check if user already exists
+        $stmt = $db->prepare("SELECT COUNT(*) FROM users WHERE username = ?");
+        $stmt->execute([$username]);
+        if ($stmt->fetchColumn() > 0) {
+            $error = "That username is already taken.";
+        } else {
+            // Create user
+            $hashed = password_hash($password, PASSWORD_DEFAULT);
+            $stmt = $db->prepare("INSERT INTO users (username, password) VALUES (?, ?)");
+            $stmt->execute([$username, $hashed]);
+
+            $_SESSION['logged_in'] = true;
+            $_SESSION['username'] = $username;
+
+            header("Location: index.php");
+            exit();
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Join</title>
+    <style>
+        body { font-family: sans-serif; padding: 2em; max-width: 500px; margin: auto; }
+        form { display: flex; flex-direction: column; gap: 1em; }
+        input[type="text"], input[type="password"] { font-size: 1.2em; padding: 0.5em; }
+        button { font-size: 1.2em; padding: 0.5em; }
+        .error { color: red; }
+    </style>
+</head>
+<body>
+    <h1>Create Account</h1>
+    <?php if ($error): ?>
+        <div class="error"><?= htmlspecialchars($error) ?></div>
+    <?php endif; ?>
+    <form method="post">
+        <label>Username:
+            <input type="text" name="username" required>
+        </label>
+        <label>Password:
+            <input type="password" name="password" required>
+        </label>
+        <button type="submit">Join</button>
+    </form>
+    <p><a href="index.php">Back to Login</a></p>
+</body>
+</html>

--- a/manage_users.php
+++ b/manage_users.php
@@ -1,0 +1,59 @@
+<?php
+// Allow only CLI
+if (php_sapi_name() !== 'cli') {
+    http_response_code(403);
+    exit("This script can only be run from the command line.\n");
+}
+
+$path = '/var/www/html/data/user_credentials.db';
+
+try {
+    $db = new PDO("sqlite:$path");
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+} catch (Exception $e) {
+    exit("Failed to connect to database: " . $e->getMessage() . "\n");
+}
+
+// Ensure users table exists
+$db->exec("CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE NOT NULL,
+    password TEXT NOT NULL
+)");
+
+$args = $argv;
+array_shift($args); // Remove the script name
+
+if (count($args) === 0) {
+    // List all usernames
+    echo "Registered users:\n";
+    $stmt = $db->query("SELECT username FROM users ORDER BY username ASC");
+    foreach ($stmt as $row) {
+        echo " - " . $row['username'] . "\n";
+    }
+    exit(0);
+}
+
+if (count($args) === 2 && $args[0] === '-remove') {
+    $target = preg_replace('/[^a-zA-Z0-9_-]/', '', $args[1]);
+
+    if ($target === '') {
+        exit("Invalid username format.\n");
+    }
+
+    $stmt = $db->prepare("DELETE FROM users WHERE username = ?");
+    $stmt->execute([$target]);
+
+    if ($stmt->rowCount() > 0) {
+        echo "User '$target' removed successfully.\n";
+    } else {
+        echo "User '$target' not found.\n";
+    }
+    exit(0);
+}
+
+// Help message
+echo "Usage:\n";
+echo "  php manage_users.php           # List all usernames\n";
+echo "  php manage_users.php -remove USERNAME   # Remove a specific user\n";
+exit(1);


### PR DESCRIPTION
## Summary
- add CLI config editor for exercises
- update create_user to accept username/password arguments
- provide a join.php page for user signups
- add manage_users.php CLI for account removal
- expand index.php with quick weight logging and exercise suggestions
- enhance suggestion endpoint

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584fdb86448331974c09c55bf1b35f