### PR TITLE
Fix group lookup in suggest.php

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -167,8 +167,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save'])) {
             $safe_key = strtolower(str_replace([' ', '-'], '_', $group));
             echo "<div class='muscle-group'>";
             echo "<h3>$group</h3>";
-            $actual_group = explode(' - ', $group)[1]; // isolates "chest"
-            echo "<label>Exercise: <select name='{$safe_key}_exercise' onchange=\"fetchSuggestion(this, '$actual_group')\">";
+            echo "<label>Exercise: <select name='{$safe_key}_exercise' onchange=\"fetchSuggestion(this, '$group')\">";
             echo "<option value=''>-- Select --</option>";
             foreach ($exercises as $exercise) echo "<option>$exercise</option>";
             echo "</select></label>";
@@ -262,9 +261,8 @@ function prepopulateFields() {
                     }
 
                     // Also trigger POST suggestion to display guidance
-                    const labelText = select.closest('.muscle-group').querySelector('h3')?.textContent;
-                    const actualGroup = labelText?.split(' - ')[1] ?? '';
-                    fetchSuggestion(select, actualGroup);
+                    const fullGroup = select.closest('.muscle-group').querySelector('h3')?.textContent ?? '';
+                    fetchSuggestion(select, fullGroup);
 
                 }
 

--- a/html/suggest.php
+++ b/html/suggest.php
@@ -69,7 +69,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $group = $_POST['muscle_group'] ?? '';
 
     if ($exercise && $group) {
-        $stmt = $workout_db->prepare("SELECT weight, reps1, reps2, reps3 FROM workouts WHERE exercise = ? AND muscle_group = ? ORDER BY date DESC LIMIT 1");
+        // muscle_group is expected to be in the "Category - Name" format, which
+        // matches how workout entries are stored.
+        $stmt = $workout_db->prepare(
+            "SELECT weight, reps1, reps2, reps3 FROM workouts " .
+            "WHERE exercise = ? AND muscle_group = ? ORDER BY date DESC LIMIT 1"
+        );
         $stmt->execute([$exercise, $group]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
 


### PR DESCRIPTION
## Summary
- resolve mismatch between exercise logging and lookup
- call suggestions with full muscle group label
- drop compatibility code for legacy muscle group names

## Testing
- `php -l html/index.php` *(fails: php not installed)*
- `php -l html/suggest.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685876d939d88331b9887732d74acb17